### PR TITLE
creates a client connection to containerd over grpc

### DIFF
--- a/pkg/kubelet/containerdshim/containerd_service.go
+++ b/pkg/kubelet/containerdshim/containerd_service.go
@@ -25,7 +25,7 @@ import (
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 
 	_ "github.com/docker/containerd/api/services/content"
-	_ "github.com/docker/containerd/api/services/execution"
+	execution "github.com/docker/containerd/api/services/execution"
 	_ "github.com/docker/containerd/api/services/shim"
 	_ "github.com/docker/containerd/api/types/container"
 	_ "github.com/docker/containerd/api/types/mount"
@@ -39,10 +39,13 @@ type ContainerdService interface {
 	http.Handler
 }
 
-type containerdService struct{}
+type containerdService struct {
+	// containerd client
+	cdClient execution.ContainerServiceClient
+}
 
-func NewContainerdService() ContainerdService {
-	return &containerdService{}
+func NewContainerdService(cdClient execution.ContainerServiceClient) ContainerdService {
+	return &containerdService{cdClient: cdClient}
 }
 
 // P4

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -29,6 +29,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/grpc"
+
+	execution "github.com/docker/containerd/api/services/execution"
 	"github.com/golang/glog"
 
 	clientgoclientset "k8s.io/client-go/kubernetes"
@@ -547,7 +550,29 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 
 		switch kubeCfg.ContainerRuntime {
 		case "containerd":
-			cs := containerdshim.NewContainerdService()
+			const (
+				// The unix socket for kubelet <-> containerdshim communication.
+				ep = "/var/run/containerdshim.sock"
+				// The unix socket for containerdshhim <-> containerd communication.
+				bindSocket = "/run/containerd/containerd.sock" // mikebrow get these from a config
+			)
+			kubeCfg.RemoteRuntimeEndpoint, kubeCfg.RemoteImageEndpoint = ep, ep
+
+			glog.V(2).Infof("Starting the GRPC client for containerd communication.")
+			// get the containerd client
+			dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithTimeout(100 * time.Second)}
+			dialOpts = append(dialOpts,
+				grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+					return net.DialTimeout("unix", bindSocket, timeout)
+				},
+				))
+			conn, err := grpc.Dial(fmt.Sprintf("unix://%s", bindSocket), dialOpts...)
+			if err != nil {
+				return nil, err
+			}
+			cdClient := execution.NewContainerServiceClient(conn)
+
+			cs := containerdshim.NewContainerdService(cdClient)
 			if err := cs.Start(); err != nil {
 				return nil, err
 			}
@@ -555,17 +580,12 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 			// kubelet, which handles the requests using ContainerdService..
 			klet.criHandler = cs
 
-			const (
-				// The unix socket for kubelet <-> containerdshim communication.
-				ep = "/var/run/containerdshim.sock"
-			)
-			kubeCfg.RemoteRuntimeEndpoint, kubeCfg.RemoteImageEndpoint = ep, ep
-
 			glog.V(2).Infof("Starting the GRPC server for the containerd CRI shim.")
 			server := containerdremote.NewContainerdServer(ep, cs)
 			if err := server.Start(); err != nil {
 				return nil, err
 			}
+
 		case "docker":
 			// Create and start the CRI shim running as a grpc server.
 			streamingConfig := getStreamingConfig(kubeCfg, kubeDeps)


### PR DESCRIPTION
Signed-off-by: Mike Brown <brownwm@us.ibm.com>

- Get a connection to containerd over the default containerd socket 
- create a execution.ContainerServiceClient
- Store the client in the DockerService / Container Manager for now till we decide where it should go.
